### PR TITLE
Issue #3: add SSL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ _trial_temp
 .pydevproject
 build/
 dist/
+stompest-doc/
 /.settings
 /.DS_Store
 /.externalToolBuilders

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,3 +20,4 @@
 * 2.2.4 - Increased test coverage of STOMP parser and fixed the uncovered bugs.
 * 2.2.5 - Increased test coverage of STOMP parser even more and fixed the uncovered bugs. Cleaned up the parser implementation.
 * 2.2.6 - Increased test coverage of STOMP parser even more and fixed the uncovered bugs. Cleaned up everything and tuned it significantly.
+* 2.3.0 - Added support for TLS/SSL thanks to [Caleb Hattingh](https://github.com/cjrh).

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3,7 +3,7 @@
 ==  Version 2.0, in this case for the stompest distribution.           ==
 =========================================================================
 
-Copyright 2012-2016, Jan Müller
+Copyright 2012-2017, Jan Müller
 All rights reserved.
 
 =========================================================================

--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ stompest is a full-featured [STOMP](http://stomp.github.com/) [1.0](http://stomp
 * The `sync.Stomp` client is dead simple. It does not assume anything about your concurrency model (thread vs process) or force you to use it any particular way. It gets out of your way and lets you do what you want.
 * The `async.Stomp` client is based on [Twisted](http://twistedmatrix.com/), a very mature and powerful asynchronous programming framework. It supports destination specific message and error handlers (with default "poison pill" error handling), concurrent message processing, graceful shutdown, and connect and disconnect timeouts.
 
-Both clients make use of a generic set of components in the `protocol` module each of which can be used independently to roll your own STOMP client:
+Both clients support [TLS/SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security) for secure connections to ActiveMQ, and both clients make use of a generic set of components in the `protocol` module, each of which can be used independently to roll your own STOMP client:
 
 * a wire-level STOMP frame parser `protocol.StompParser` and compiler `protocol.StompFrame`,
 

--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,26 @@ Installation
 
 Documentation & Code Examples
 =============================
+
 The stompest API is fully documented [here](http://nikipore.github.com/stompest/).
+
+Building
+--------
+
+To *build* the documentation, you'll need a source checkout, and then first install the documentation dependencies into your virtual environment:
+
+```
+(env) $ pip install -e .[doc]
+```
+
+Then you can build the documentation in the `doc/` directory:
+
+```
+(env) $ cd doc/
+(env) $ make html
+```
+
+The HTML documentation will be in the directory `doc/stompest-doc`.
 
 Questions or Suggestions?
 =========================

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = ../../stompest-doc
+BUILDDIR      = stompest-doc
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4

--- a/doc/make
+++ b/doc/make
@@ -1,4 +1,0 @@
-#!/bin/bash
-source ~/.profile
-source ${WORKON_HOME}/${STOMPEST_DEV_ENV}/bin/activate
-make html

--- a/src/async/README.txt
+++ b/src/async/README.txt
@@ -1,7 +1,12 @@
 stomp, stomper, stompest!
 =========================
 
-This package provides the asynchronous STOMP client based upon the `stompest <https://pypi.python.org/pypi/stompest/>`_ library. It leverages the power of `Twisted <http://twistedmatrix.com/>`_, a very mature and powerful asynchronous programming framework. The client supports destination specific message and error handlers (with default "poison pill" error handling), concurrent message processing, graceful shutdown, and connect, receipt, and disconnect timeouts.
+This package provides the asynchronous STOMP client based upon the `stompest <https://pypi.python.org/pypi/stompest/>`_ library. It leverages the power of `Twisted <http://twistedmatrix.com/>`_, a very mature and powerful asynchronous programming framework. The client supports
+
+- destination-specific message and error handlers (with default "poison pill" error handling)
+- concurrent message processing
+- graceful shutdown, and connect, receipt, and disconnect timeouts
+- optional TLS/SSL support
 
 Installation
 ============

--- a/src/async/setup.py
+++ b/src/async/setup.py
@@ -30,10 +30,11 @@ setup(
     install_requires=[
         'stompest==%s' % FULL_VERSION
         , 'twisted>=16.4.0'
-        , 'pyopenssl'
+    ],
+    tests_require=(['mock'] if sys.version_info[0] == 2 else []) + [
+        'pyopenssl'
         , 'service_identity'
     ],
-    tests_require=['mock'] if sys.version_info[0] == 2 else [],
     test_suite='stompest.async.tests',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/src/async/setup.py
+++ b/src/async/setup.py
@@ -29,12 +29,9 @@ setup(
     zip_safe=True,
     install_requires=[
         'stompest==%s' % FULL_VERSION
-        , 'twisted>=16.4.0'
+        , 'twisted[tls] >= 16.4.0'
     ],
-    tests_require=(['mock'] if sys.version_info[0] == 2 else []) + [
-        'pyopenssl'
-        , 'service_identity'
-    ],
+    tests_require=['mock'] if sys.version_info[0] == 2 else [],
     test_suite='stompest.async.tests',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/src/async/setup.py
+++ b/src/async/setup.py
@@ -30,6 +30,8 @@ setup(
     install_requires=[
         'stompest==%s' % FULL_VERSION
         , 'twisted>=16.4.0'
+        , 'pyopenssl'
+        , 'service_identity'
     ],
     tests_require=['mock'] if sys.version_info[0] == 2 else [],
     test_suite='stompest.async.tests',

--- a/src/async/stompest/__init__.py
+++ b/src/async/stompest/__init__.py
@@ -6,5 +6,5 @@ except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__) # @ReservedAssignment
 
-VERSION = '2.2'
-FULL_VERSION = '2.2.6'
+VERSION = '2.3'
+FULL_VERSION = '2.3.0'

--- a/src/async/stompest/async/client.py
+++ b/src/async/stompest/async/client.py
@@ -1,6 +1,9 @@
 """The asynchronous client is based on `Twisted <http://twistedmatrix.com/>`_, a very mature and powerful asynchronous programming framework. It supports destination specific message and error handlers (with default "poison pill" error handling), concurrent message processing, graceful shutdown, and connect and disconnect timeouts.
 
-.. seealso:: `STOMP protocol specification <http://stomp.github.com/>`_, `Twisted API documentation <http://twistedmatrix.com/documents/current/api/>`_, `Apache ActiveMQ - Stomp <http://activemq.apache.org/stomp.html>`_
+TLS/SSL support may be configured on the :class:`~.StompConfig` object
+in exactly the same way as demonstrated in the sync client.
+
+.. seealso:: `STOMP protocol specification <http://stomp.github.com/>`_, `Twisted API documentation <http://twistedmatrix.com/documents/current/api/>`_, `Apache ActiveMQ - Stomp <http://activemq.apache.org/stomp.html>`_, `Apache ActiveMQ - SSL <http://activemq.apache.org/how-do-i-use-ssl.html>`_
 
 Examples
 --------

--- a/src/async/stompest/async/tests/async_client_integration_test.py
+++ b/src/async/stompest/async/tests/async_client_integration_test.py
@@ -492,7 +492,8 @@ class SSLSettingsMixin(object):
     port = PORT_SSL
 
     sslContext = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-    sslContext.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+    # It's good practice to disable insecure protocols by default
+    sslContext.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_SSLv3
     # Disable host name and cert checking for the tests.
     sslContext.check_hostname = False
     sslContext.verify_mode = ssl.CERT_NONE

--- a/src/async/stompest/async/tests/async_client_integration_test.py
+++ b/src/async/stompest/async/tests/async_client_integration_test.py
@@ -26,7 +26,7 @@ class AsyncClientBaseTestCase(unittest.TestCase):
     headers = {StompSpec.ID_HEADER: '4711'}
     protocol = 'tcp'
     port = PORT
-    ssl_context = None
+    sslContext = None
 
     TIMEOUT = 0.2
 
@@ -35,7 +35,7 @@ class AsyncClientBaseTestCase(unittest.TestCase):
         return StompConfig(
             '%s://%s:%s' % (self.protocol, HOST, port or self.port),
             login=LOGIN, passcode=PASSCODE, version=version,
-            ssl_context=self.ssl_context,
+            sslContext=self.sslContext,
         )
 
     def cleanQueues(self):
@@ -491,11 +491,11 @@ class SSLSettingsMixin(object):
     protocol = 'ssl'
     port = PORT_SSL
 
-    ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-    ssl_context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+    sslContext = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    sslContext.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
     # Disable host name and cert checking for the tests.
-    ssl_context.check_hostname = False
-    ssl_context.verify_mode = ssl.CERT_NONE
+    sslContext.check_hostname = False
+    sslContext.verify_mode = ssl.CERT_NONE
 
 
 class HandlerExceptionWithErrorQueueIntegrationTestCaseSSL(

--- a/src/core/README.txt
+++ b/src/core/README.txt
@@ -1,7 +1,7 @@
 stomp, stomper, stompest!
 =========================
 
-`stompest <https://github.com/nikipore/stompest/>`_ is a full-featured `STOMP <http://stomp.github.com/>`_ `1.0 <http://stomp.github.com//stomp-specification-1.0.html>`_, `1.1 <http://stomp.github.com//stomp-specification-1.1.html>`_, and `1.2 <http://stomp.github.com//stomp-specification-1.2.html>`_ implementation for Python 2.7 and Python 3 (versions 3.3 and higher).
+`stompest <https://github.com/nikipore/stompest/>`_ is a full-featured `STOMP <http://stomp.github.com/>`_ `1.0 <http://stomp.github.com//stomp-specification-1.0.html>`_, `1.1 <http://stomp.github.com//stomp-specification-1.1.html>`_, and `1.2 <http://stomp.github.com//stomp-specification-1.2.html>`_ implementation for Python 2.7 and Python 3 (versions 3.3 and higher), with optional TLS/SSL support.
 
 The STOMP client in this package is dead simple: It does not assume anything about your concurrency model (thread vs process) or force you to use it any particular way. It gets out of your way and lets you do what you want. The package also consists of a generic set of components each of which you may use independently to roll your own STOMP client:
 
@@ -31,7 +31,7 @@ Feel free to `open an issue <https://github.com/nikipore/stompest/issues/>`_ or 
 
 Acknowledgements
 ================
-* Version 1.x of stompest was written by `Roger Hoover <http://github.com/theduderog/>`_ at `Mozes <http://www.mozes.com/>`_ and deployed in their production environment.
+* Version 1.x of stompest was written by `Roger Hoover <http://github.com/theduderog/>`_ at Mozes_ and deployed in their production environment.
 * Kudos to `Oisin Mulvihill <https://github.com/oisinmulvihill/>`_, the developer of `stomper <http://code.google.com/p/stomper/>`_! The idea of an abstract representation of the STOMP protocol lives on in stompest.
 
 Documentation & Code Examples

--- a/src/core/setup.py
+++ b/src/core/setup.py
@@ -29,6 +29,7 @@ setup(
     zip_safe=True,
     install_requires=[],
     tests_require=['mock'] if sys.version_info[0] == 2 else [],
+    extras_require={'doc': 'sphinx'},
     test_suite='stompest.tests',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/src/core/stompest/__init__.py
+++ b/src/core/stompest/__init__.py
@@ -6,5 +6,5 @@ except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__) # @ReservedAssignment
 
-VERSION = '2.2'
-FULL_VERSION = '2.2.6'
+VERSION = '2.3'
+FULL_VERSION = '2.3.0'

--- a/src/core/stompest/config/__init__.py
+++ b/src/core/stompest/config/__init__.py
@@ -6,12 +6,37 @@ class StompConfig(object):
     :param passcode: The passcode for the STOMP brokers. The default is :obj:`None`, which means that no **passcode** header will be sent.
     :param version: A valid STOMP protocol version, or :obj:`None` (equivalent to the :attr:`DEFAULT_VERSION` attribute of the :class:`~.StompSpec` class).
     :param check: Decides whether the :class:`~.StompSession` object which is used to represent the STOMP sesion should be strict about the session's state: (e.g., whether to allow calling the session's :meth:`~.StompSession.send` when disconnected).
-    :param sslContext: An SSL context to wrap around a TCP socket connection.
+    :param sslContext: An SSL context to wrap around a TCP socket connection. This object is defined in the Python standard library: `ssl.SSLContext <https://docs.python.org/3/library/ssl.html#ssl.SSLContext>`_
     :type sslContext: ssl.SSLContext
 
     .. note :: Login and passcode have to be the same for all brokers because they are not part of the failover URI scheme.
 
     .. seealso :: The :class:`~.StompFailoverTransport` class which tells you which broker to use and how long you should wait to connect to it, the :class:`~.StompFailoverUri` which parses failover transport URIs.
+
+    *SSL Example*
+
+    .. code-block:: python
+
+        import ssl
+        sslContext = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        # It's good practice to disable insecure protocols by default. Note that
+        # since Python 3.6, SSLv3 is disabled by default.
+        sslContext.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_SSLv3
+
+        # For testing and development, it is often useful to disable host cert
+        # validation, which requires *both* of the following settings.
+        sslContext.check_hostname = False
+        sslContext.verify_mode = ssl.CERT_NONE
+
+        # Create the StompConfig as usual. Remember that for TLS/SSL, the URI should
+        # begin with "ssl"
+        config = StompConfig(
+            'ssl://host.com',
+            login='admin',
+            passcode='admin',
+            sslContext=sslContext
+        )
+
     """
     def __init__(self, uri, login=None, passcode=None, version=None, check=True, sslContext=None):
         self.uri = uri

--- a/src/core/stompest/config/__init__.py
+++ b/src/core/stompest/config/__init__.py
@@ -6,17 +6,17 @@ class StompConfig(object):
     :param passcode: The passcode for the STOMP brokers. The default is :obj:`None`, which means that no **passcode** header will be sent.
     :param version: A valid STOMP protocol version, or :obj:`None` (equivalent to the :attr:`DEFAULT_VERSION` attribute of the :class:`~.StompSpec` class).
     :param check: Decides whether the :class:`~.StompSession` object which is used to represent the STOMP sesion should be strict about the session's state: (e.g., whether to allow calling the session's :meth:`~.StompSession.send` when disconnected).
-    :param ssl_context: An SSL context to wrap around a TCP socket connection.
-    :type ssl_context: ssl.SSLContext
+    :param sslContext: An SSL context to wrap around a TCP socket connection.
+    :type sslContext: ssl.SSLContext
 
     .. note :: Login and passcode have to be the same for all brokers because they are not part of the failover URI scheme.
 
     .. seealso :: The :class:`~.StompFailoverTransport` class which tells you which broker to use and how long you should wait to connect to it, the :class:`~.StompFailoverUri` which parses failover transport URIs.
     """
-    def __init__(self, uri, login=None, passcode=None, version=None, check=True, ssl_context=None):
+    def __init__(self, uri, login=None, passcode=None, version=None, check=True, sslContext=None):
         self.uri = uri
         self.login = login
         self.passcode = passcode
         self.version = version
         self.check = check
-        self.ssl_context = ssl_context
+        self.sslContext = sslContext

--- a/src/core/stompest/config/__init__.py
+++ b/src/core/stompest/config/__init__.py
@@ -6,14 +6,17 @@ class StompConfig(object):
     :param passcode: The passcode for the STOMP brokers. The default is :obj:`None`, which means that no **passcode** header will be sent.
     :param version: A valid STOMP protocol version, or :obj:`None` (equivalent to the :attr:`DEFAULT_VERSION` attribute of the :class:`~.StompSpec` class).
     :param check: Decides whether the :class:`~.StompSession` object which is used to represent the STOMP sesion should be strict about the session's state: (e.g., whether to allow calling the session's :meth:`~.StompSession.send` when disconnected).
+    :param ssl_context: An SSL context to wrap around a TCP socket connection.
+    :type ssl_context: ssl.SSLContext
 
     .. note :: Login and passcode have to be the same for all brokers because they are not part of the failover URI scheme.
 
     .. seealso :: The :class:`~.StompFailoverTransport` class which tells you which broker to use and how long you should wait to connect to it, the :class:`~.StompFailoverUri` which parses failover transport URIs.
     """
-    def __init__(self, uri, login=None, passcode=None, version=None, check=True):
+    def __init__(self, uri, login=None, passcode=None, version=None, check=True, ssl_context=None):
         self.uri = uri
         self.login = login
         self.passcode = passcode
         self.version = version
         self.check = check
+        self.ssl_context = ssl_context

--- a/src/core/stompest/protocol/failover.py
+++ b/src/core/stompest/protocol/failover.py
@@ -140,7 +140,7 @@ class StompFailoverUri(object):
     _bool = {'true': True, 'false': False}.__getitem__
 
     _FAILOVER_PREFIX = 'failover:'
-    _REGEX_URI = re.compile('^(?P<protocol>tcp)://(?P<host>[^:]+):(?P<port>\d+)$')
+    _REGEX_URI = re.compile('^(?P<protocol>(tcp|ssl))://(?P<host>[^:]+):(?P<port>\d+)$')
     _REGEX_BRACKETS = re.compile('^\((?P<uri>.+)\)$')
     _SUPPORTED_OPTIONS = {
         'initialReconnectDelay': _configurationOption(int, 10)

--- a/src/core/stompest/sync/client.py
+++ b/src/core/stompest/sync/client.py
@@ -16,6 +16,35 @@ Consumer
 
 .. literalinclude:: ../../src/core/stompest/sync/examples/consumer.py
 
+TLS/SSL Consumer
+^^^^^^^^^^^^^^^^
+
+.. literalinclude:: ../../src/core/stompest/sync/examples/ssl_consumer.py
+
+An SSL producer would be configured in the same way.  The configuration
+of an SSL-enabled ActiveMQ server is somewhat complicated. The config
+file for ActiveMQ, `activemq.xml`, must have the following additions:
+
+.. code-block:: xml
+
+    <!-- add this to the config file "activemq.xml" -->
+    <sslContext>
+        <sslContext
+            keyStore="file:/broker.ks" keyStorePassword="broker"
+            trustStore="file:/client.ts" trustStorePassword="broker"/>
+    </sslContext>
+    <transportConnectors>
+        <transportConnector name="stomp+ssl" uri="stomp+ssl://0.0.0.0:61612"/>
+        <transportConnector name="stomp" uri="stomp://0.0.0.0:61613"/>
+    </transportConnectors>
+
+The SSL transport configuration (on port 61612) is shown alongside the standard
+STOMP configuration (on port 61613) for contrast. More about the required ActiveMQ setup,
+as well as instructions to generate the files `broker.ks` and `client.ts` may
+be found in the ActiveMQ documentation under
+`How do I use SSL <http://activemq.apache.org/how-do-i-use-ssl.html>`_.
+
+
 API
 ---
 """

--- a/src/core/stompest/sync/client.py
+++ b/src/core/stompest/sync/client.py
@@ -83,7 +83,9 @@ class Stomp(object):
 
         try:
             for (broker, connectDelay) in self._failover:
-                transport = self._transportFactory(broker['host'], broker['port'])
+                transport = self._transportFactory(
+                    broker['host'], broker['port'], ssl_context=self._config.ssl_context,
+                )
                 if connectDelay:
                     self.log.debug('Delaying connect attempt for %d ms' % int(connectDelay * 1000))
                     time.sleep(connectDelay)

--- a/src/core/stompest/sync/client.py
+++ b/src/core/stompest/sync/client.py
@@ -84,7 +84,7 @@ class Stomp(object):
         try:
             for (broker, connectDelay) in self._failover:
                 transport = self._transportFactory(
-                    broker['host'], broker['port'], ssl_context=self._config.ssl_context,
+                    broker['host'], broker['port'], sslContext=self._config.sslContext,
                 )
                 if connectDelay:
                     self.log.debug('Delaying connect attempt for %d ms' % int(connectDelay * 1000))

--- a/src/core/stompest/sync/examples/ssl_consumer.py
+++ b/src/core/stompest/sync/examples/ssl_consumer.py
@@ -1,0 +1,22 @@
+import ssl
+from stompest.config import StompConfig
+from stompest.protocol import StompSpec
+from stompest.sync import Stomp
+
+context = ssl.create_default_context()
+# Disable cert validation for demo only
+context.check_hostname = False
+context.verify_mode = ssl.CERT_NONE
+
+CONFIG = StompConfig('ssl://localhost:61612', sslContext=context)
+QUEUE = '/queue/test'
+
+if __name__ == '__main__':
+    client = Stomp(CONFIG)
+    client.connect()
+    client.subscribe(QUEUE, {StompSpec.ACK_HEADER: StompSpec.ACK_CLIENT_INDIVIDUAL})
+    while True:
+        frame = client.receiveFrame()
+        print('Got %s' % frame.info())
+        client.ack(frame)
+    client.disconnect()

--- a/src/core/stompest/sync/transport.py
+++ b/src/core/stompest/sync/transport.py
@@ -14,10 +14,10 @@ class StompFrameTransport(object):
 
     READ_SIZE = 4096
 
-    def __init__(self, host, port, ssl_context=None):
+    def __init__(self, host, port, sslContext=None):
         self.host = host
         self.port = port
-        self.ssl_context = ssl_context
+        self.sslContext = sslContext
 
         self._socket = None
         self._parser = self.factory()
@@ -49,8 +49,8 @@ class StompFrameTransport(object):
         try:
             self._socket = socket.socket()
             self._socket.settimeout(timeout)
-            if self.ssl_context:
-                self._socket = self.ssl_context.wrap_socket(self._socket, server_hostname=self.host)
+            if self.sslContext:
+                self._socket = self.sslContext.wrap_socket(self._socket, server_hostname=self.host)
             self._socket.connect((self.host, self.port))
         except IOError as e:
             raise StompConnectionError('Could not establish connection [%s]' % e)

--- a/src/core/stompest/tests/__init__.py
+++ b/src/core/stompest/tests/__init__.py
@@ -1,5 +1,6 @@
 HOST = 'localhost'
 PORT = 61613
+PORT_SSL = 61612
 VERSION = '1.2'
 
 BROKER = 'activemq'

--- a/src/core/stompest/tests/failover_test.py
+++ b/src/core/stompest/tests/failover_test.py
@@ -35,7 +35,7 @@ class StompFailoverUriTest(unittest.TestCase):
 
     def test_configuration_invalid_uris(self):
         for uri in [
-            'ssl://localhost:61613', 'tcp://:61613', 'tcp://61613', 'tcp:localhost:61613', 'tcp:/localhost',
+            'tcp://:61613', 'tcp://61613', 'tcp:localhost:61613', 'tcp:/localhost',
             'tcp://localhost:', 'tcp://localhost:a', 'tcp://localhost:61613?randomize=1', 'tcp://localhost:61613?randomize=True',
             'tcp://localhost:61613??=False', 'tcp://localhost:61613?a=False', 'tcp://localhost:61613?maxReconnectDelay=False'
             'failover:(tcp://primary:61616, tcp://secondary:61616)', 'failover:tcp://primary:61616, tcp://secondary:61616',


### PR DESCRIPTION
I went through several designs, but this is by far the cleanest: let the user build their own `SSLContext` and pass that in as part of `StompConfig`.

I tested this against **ActiveMQ 5.13.0**, running under docker.  It was a real pain to set up an amq instance with SSL enabled.  (The one I used is `cjrh/amq` on dockerhub).

I tested with **Python 3.6.0**, although it should "just work" under 2.7. I just haven't run the tests under 2.7 yet.

- For some reason _Twisted_ complained about _pyopenssl_  and _service_identity_ being missing, but I already had _Twisted_ installed and it didn't install them as deps. I didn't look into it any deeper than that, so you may want to verify whether they really do need to be added to the `install_requires` or not.
- As for testing, it was easiest to simply rerun all the existing integration tests, but under SSL, rather than come up with new tests. I don't know which direction you wanted to go in here.