### PR TITLE
ignore disconnect errors while cleaning up from a timed out connect attempt

### DIFF
--- a/src/core/stompest/sync/client.py
+++ b/src/core/stompest/sync/client.py
@@ -136,11 +136,7 @@ class Stomp(object):
         frame = self.session.connect(self._config.login, self._config.passcode, headers, versions, host, heartBeats)
         self.sendFrame(frame)
         if not self.canRead(timeout):
-            try:
-                self.session.disconnect()
-            except:
-                # Ignore disconnect attempt errors, since we may be in a bad state
-                pass
+            self.session.close()
             raise StompProtocolError('STOMP session connect failed [timeout=%s]' % timeout)
         frame = self.receiveFrame()
         self.session.connected(frame)

--- a/src/core/stompest/sync/client.py
+++ b/src/core/stompest/sync/client.py
@@ -136,7 +136,11 @@ class Stomp(object):
         frame = self.session.connect(self._config.login, self._config.passcode, headers, versions, host, heartBeats)
         self.sendFrame(frame)
         if not self.canRead(timeout):
-            self.session.disconnect()
+            try:
+                self.session.disconnect()
+            except:
+                # Ignore disconnect attempt errors, since we may be in a bad state
+                pass
             raise StompProtocolError('STOMP session connect failed [timeout=%s]' % timeout)
         frame = self.receiveFrame()
         self.session.connected(frame)


### PR DESCRIPTION
Seems like the cleaning up after a failed connect, fails again on trying to disconnect in connecting state, I think my change fixes it, but if you have other suggestions on a better way to do it, let me know, I'm happy to help out.

The errors I got looked like this (sorry about the weird formatting):

> /py3/lib/python3.5/site-packages/stompest/sync/client.py:98:` in connect
    self._connect(headers, versions, host, heartBeats, connectedTimeout)
/py3/lib/python3.5/site-packages/stompest/sync/client.py:108: in _connect
	    self.session.disconnect()
/py3/lib/python3.5/site-packages/stompest/protocol/session.py:98: in disconnect
	    self.__check('disconnect', [self.CONNECTED])
>_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
	
>self = <stompest.protocol.session.StompSession object at 0x7f525d6b3358>
command = 'disconnect', states = ['connected']

>    def __check(self, command, states):
        if self._check and (self.state not in states):
           raise StompProtocolError('Cannot handle command %s in state %s (only in states %s)' % (repr(command), repr(self.state), ', '.join(map(repr, states))))
           stompest.error.StompProtocolError: Cannot handle command 'disconnect' in state 'connecting' (only in states 'connected')
