### PR TITLE
Fix URL due to 404 error

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ Installation
 Documentation & Code Examples
 =============================
 
-The stompest API is fully documented [here](http://nikipore.github.com/stompest/).
+The stompest API is fully documented [here](http://nikipore.github.io/stompest/).
 
 Building
 --------


### PR DESCRIPTION
Subdomains of github.com are deprecated for GitHub Pages. They will not redirect to github.io after April 15, 2021.